### PR TITLE
Fixes Create Diesel Generators not consuming fuel while producing SU

### DIFF
--- a/kubejs/server_scripts/server_compatability/createdieselgenerators.js
+++ b/kubejs/server_scripts/server_compatability/createdieselgenerators.js
@@ -71,48 +71,48 @@ if (Platform.isLoaded("createdieselgenerators")) {
 
     CDGEvents.fuelTypes((event) => {
         event.add("thermal:creosote").normalSpeed(64).normalStrength(2048).normalBurn(2)
-            .modularSpeed(32).modularStrength(3072).normalBurn(6)
-            .hugeSpeed(32).hugeStrength(3072).normalBurn(6)
+            .modularSpeed(32).modularStrength(3072).modularBurn(6)
+            .hugeSpeed(32).hugeStrength(3072).hugeBurn(6)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("thermal:heavy_oil").normalSpeed(64).normalStrength(2048).normalBurn(2)
-            .modularSpeed(96).modularStrength(6144).normalBurn(3)
-            .hugeSpeed(128).hugeStrength(12288).normalBurn(4)
+            .modularSpeed(96).modularStrength(6144).modularBurn(3)
+            .hugeSpeed(128).hugeStrength(12288).hugeBurn(4)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("thermal:light_oil").normalSpeed(64).normalStrength(3072).normalBurn(2)
-            .modularSpeed(128).modularStrength(6144).normalBurn(3)
-            .hugeSpeed(96).hugeStrength(6144).normalBurn(6)
+            .modularSpeed(128).modularStrength(6144).modularBurn(3)
+            .hugeSpeed(96).hugeStrength(6144).hugeBurn(6)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("thermal:refined_fuel").normalSpeed(64).normalStrength(4096).normalBurn(1)
-            .modularSpeed(128).modularStrength(8192).normalBurn(2)
-            .hugeSpeed(128).hugeStrength(16384).normalBurn(4)
+            .modularSpeed(128).modularStrength(8192).modularBurn(2)
+            .hugeSpeed(128).hugeStrength(16384).hugeBurn(4)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("thermal:tree_oil").normalSpeed(32).normalStrength(1024).normalBurn(1)
-            .modularSpeed(64).modularStrength(2048).normalBurn(2)
-            .hugeSpeed(64).hugeStrength(3072).normalBurn(6)
+            .modularSpeed(64).modularStrength(2048).modularBurn(2)
+            .hugeSpeed(64).hugeStrength(3072).hugeBurn(6)
             .soundSpeed(1).burnerStrength(1).build();
         event.add("#forge:biofuel").normalSpeed(64).normalStrength(4096).normalBurn(3)
-            .modularSpeed(128).modularStrength(8192).normalBurn(6)
-            .hugeSpeed(128).hugeStrength(12288).normalBurn(12)
+            .modularSpeed(128).modularStrength(8192).modularBurn(6)
+            .hugeSpeed(128).hugeStrength(12288).hugeBurn(12)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("#forge:diesel").normalSpeed(64).normalStrength(2048).normalBurn(2)
-            .modularSpeed(96).modularStrength(6144).normalBurn(3)
-            .hugeSpeed(128).hugeStrength(12288).normalBurn(4)
+            .modularSpeed(96).modularStrength(6144).modularBurn(3)
+            .hugeSpeed(128).hugeStrength(12288).hugeBurn(4)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("#forge:gasoline").normalSpeed(64).normalStrength(2048).normalBurn(2)
-            .modularSpeed(32).modularStrength(3072).normalBurn(6)
-            .hugeSpeed(32).hugeStrength(3072).normalBurn(6)
+            .modularSpeed(32).modularStrength(3072).modularBurn(6)
+            .hugeSpeed(32).hugeStrength(3072).hugeBurn(6)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("#forge:ethanol").normalSpeed(64).normalStrength(3072).normalBurn(3)
-            .modularSpeed(96).modularStrength(6144).normalBurn(6)
-            .hugeSpeed(96).hugeStrength(6144).normalBurn(12)
+            .modularSpeed(96).modularStrength(6144).modularBurn(6)
+            .hugeSpeed(96).hugeStrength(6144).hugeBurn(12)
             .soundSpeed(2).burnerStrength(1).build();
         event.add("#forge:gasoline").normalSpeed(64).normalStrength(3072).normalBurn(2)
-            .modularSpeed(128).modularStrength(6144).normalBurn(3)
-            .hugeSpeed(96).hugeStrength(6144).normalBurn(6)
+            .modularSpeed(128).modularStrength(6144).modularBurn(3)
+            .hugeSpeed(96).hugeStrength(6144).hugeBurn(6)
             .soundSpeed(3).burnerStrength(1).build();
         event.add("#forge:plantoil").normalSpeed(32).normalStrength(1024).normalBurn(1)
-            .modularSpeed(64).modularStrength(2048).normalBurn(2)
-            .hugeSpeed(64).hugeStrength(3072).normalBurn(6)
+            .modularSpeed(64).modularStrength(2048).modularBurn(2)
+            .hugeSpeed(64).hugeStrength(3072).hugeBurn(6)
             .soundSpeed(1).burnerStrength(1).build();
     });
 }


### PR DESCRIPTION
Only the normal generator was consuming fuel while working, as the `modularBurn` and `hugeBurn` for each fuel was incorrectly defined
